### PR TITLE
replaced coma by semi-colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a js library for Backbase [REST API](https://my.backbase.com/resources/d
 #### nodejs
 
 ``` javascript
-var BBRest = require('mosaic-rest-js'),
+var BBRest = require('mosaic-rest-js');
 var bbrest = new BBRest({
    portal: 'myPortal'
  });


### PR DESCRIPTION
Replaced a coma by a semi-colon at the end of an expression.

I copy-pasted the snippet to quickly get the feel of how it works and run into this small thing.
It's the second time that I ran into it in 2 days so let's just send a quick typo-fix. :)